### PR TITLE
Add user management and dashboard

### DIFF
--- a/mock/dashboard/user.ts
+++ b/mock/dashboard/user.ts
@@ -1,0 +1,21 @@
+import { defineMock } from '@alova/mock';
+import { faker } from '@faker-js/faker';
+import { resultSuccess } from '../_util';
+import { adminToken } from '../user';
+
+function makeUser() {
+  return {
+    id: faker.string.numeric(4),
+    username: faker.internet.userName(),
+    demandCount: faker.number.int({ min: 1, max: 20 }),
+    resumeCount: faker.number.int({ min: 1, max: 50 }),
+  };
+}
+
+export default defineMock({
+  '/api/dashboard/user': ({ headers }) => {
+    const isAdmin = headers?.token === adminToken;
+    const list = isAdmin ? Array.from({ length: 5 }, makeUser) : [makeUser()];
+    return resultSuccess({ list });
+  },
+});

--- a/mock/system/user.ts
+++ b/mock/system/user.ts
@@ -1,0 +1,34 @@
+import { defineMock } from '@alova/mock';
+import { faker } from '@faker-js/faker';
+import { doCustomTimes, resultSuccess } from '../_util';
+
+function userList(pageSize: number) {
+  const result: any[] = [];
+  doCustomTimes(pageSize, () => {
+    result.push({
+      id: faker.string.numeric(4),
+      username: faker.internet.userName(),
+      email: faker.internet.email(),
+      status: faker.helpers.arrayElement([1, 0]),
+    });
+  });
+  return result;
+}
+
+export default defineMock({
+  '/api/user/list': ({ query }) => {
+    const { page = 1, pageSize = 10 } = query;
+    const list = userList(Number(pageSize));
+    const count = 60;
+    return resultSuccess({
+      page: Number(page),
+      pageSize: Number(pageSize),
+      pageCount: count,
+      itemCount: count * Number(pageSize),
+      list,
+    });
+  },
+  '/api/user/toggle/:id': () => {
+    return resultSuccess(true);
+  },
+});

--- a/mock/user/index.ts
+++ b/mock/user/index.ts
@@ -4,16 +4,16 @@ import { defineMock } from '@alova/mock';
 
 const Random = Mock.Random;
 
-const token = Random.string('upper', 32, 32);
+export const adminToken = Random.string('upper', 32, 32);
 
-const adminInfo = {
+export const adminInfo = {
   userId: '1',
   username: 'admin',
   realName: 'Admin',
   avatar: Random.image(),
   desc: 'manager',
   password: Random.string('upper', 4, 16),
-  token,
+  token: adminToken,
   permissions: [
     {
       label: '主控台',
@@ -35,10 +35,18 @@ const adminInfo = {
       label: '基础列表删除',
       value: 'basic_list_delete',
     },
+    {
+      label: '用户管理',
+      value: 'system_user_manage',
+    },
+    {
+      label: '用户仪表盘',
+      value: 'user_dashboard',
+    },
   ],
 };
 
 export default defineMock({
-  '[POST]/api/login': () => resultSuccess({ token }),
+  '[POST]/api/login': () => resultSuccess({ token: adminToken }),
   '/api/admin_info': () => resultSuccess(adminInfo),
 });

--- a/src/api/dashboard/user.ts
+++ b/src/api/dashboard/user.ts
@@ -1,0 +1,12 @@
+import { Alova } from '@/utils/http/alova/index';
+
+export interface UserDashboardItem {
+  id: number;
+  username: string;
+  demandCount: number;
+  resumeCount: number;
+}
+
+export function getUserDashboard(params?) {
+  return Alova.Get<{ list: UserDashboardItem[] }>('/dashboard/user', { params });
+}

--- a/src/api/system/sysUser.ts
+++ b/src/api/system/sysUser.ts
@@ -1,0 +1,17 @@
+import { Alova } from '@/utils/http/alova/index';
+
+export interface SysUserItem {
+  id: number;
+  username: string;
+  email: string;
+  status: number;
+  [key: string]: any;
+}
+
+export function getUserList(params?) {
+  return Alova.Get<{ list: SysUserItem[] }>('/user/list', { params });
+}
+
+export function toggleUser(id: number) {
+  return Alova.Post(`/user/toggle/${id}`);
+}

--- a/src/router/modules/dashboard.ts
+++ b/src/router/modules/dashboard.ts
@@ -47,6 +47,15 @@ const routes: Array<RouteRecordRaw> = [
         },
         component: () => import('@/views/dashboard/workplace/workplace.vue'),
       },
+      {
+        path: 'user',
+        name: `${routeName}_user`,
+        meta: {
+          title: '用户仪表盘',
+          permissions: ['user_dashboard'],
+        },
+        component: () => import('@/views/dashboard/user/user.vue'),
+      },
     ],
   },
 ];

--- a/src/router/modules/system.ts
+++ b/src/router/modules/system.ts
@@ -31,6 +31,15 @@ const routes: Array<RouteRecordRaw> = [
         },
         component: () => import('@/views/system/role/role.vue'),
       },
+      {
+        path: 'user',
+        name: 'system_user',
+        meta: {
+          title: '用户管理',
+          permissions: ['system_user_manage'],
+        },
+        component: () => import('@/views/system/user/user.vue'),
+      },
     ],
   },
 ];

--- a/src/utils/http/alova/mocks.ts
+++ b/src/utils/http/alova/mocks.ts
@@ -3,8 +3,19 @@
 import UserMock from '../../../../mock/user';
 import MenusMock from '../../../../mock/user/menus';
 import ConsoleMock from '../../../../mock/dashboard/console';
+import UserDashboardMock from '../../../../mock/dashboard/user';
 import TableMock from '../../../../mock/table/list';
 import SystemMenuMock from '../../../../mock/system/menu';
 import SystemRoleMock from '../../../../mock/system/role';
+import SystemUserMock from '../../../../mock/system/user';
 
-export default [UserMock, MenusMock, TableMock, ConsoleMock, SystemMenuMock, SystemRoleMock];
+export default [
+  UserMock,
+  MenusMock,
+  TableMock,
+  ConsoleMock,
+  UserDashboardMock,
+  SystemMenuMock,
+  SystemRoleMock,
+  SystemUserMock,
+];

--- a/src/views/dashboard/user/columns.ts
+++ b/src/views/dashboard/user/columns.ts
@@ -1,0 +1,9 @@
+import { BasicColumn } from '@/components/Table';
+import type { UserDashboardItem } from '@/api/dashboard/user';
+
+export const columns: BasicColumn<UserDashboardItem>[] = [
+  { title: 'ID', key: 'id', width: 80 },
+  { title: '用户名', key: 'username' },
+  { title: '需求数量', key: 'demandCount' },
+  { title: '简历数量', key: 'resumeCount' },
+];

--- a/src/views/dashboard/user/user.vue
+++ b/src/views/dashboard/user/user.vue
@@ -1,0 +1,25 @@
+<template>
+  <n-card :bordered="false" class="proCard">
+    <BasicTable
+      title="用户数据"
+      :columns="columns"
+      :request="loadData"
+      :row-key="(row) => row.id"
+    />
+  </n-card>
+</template>
+
+<script lang="ts" setup>
+  import { reactive } from 'vue';
+  import { BasicTable } from '@/components/Table';
+  import { getUserDashboard } from '@/api/dashboard/user';
+  import { columns } from './columns';
+
+  const params = reactive({});
+
+  const loadData = async (res) => {
+    return await getUserDashboard({ ...params, ...res });
+  };
+</script>
+
+<style scoped></style>

--- a/src/views/system/user/columns.ts
+++ b/src/views/system/user/columns.ts
@@ -1,0 +1,27 @@
+import { h } from 'vue';
+import { NTag } from 'naive-ui';
+import { BasicColumn } from '@/components/Table';
+
+export interface UserItem {
+  id: number;
+  username: string;
+  email: string;
+  status: number;
+}
+
+export const columns: BasicColumn<UserItem>[] = [
+  { title: 'ID', key: 'id', width: 80 },
+  { title: '用户名', key: 'username' },
+  { title: '邮箱', key: 'email' },
+  {
+    title: '状态',
+    key: 'status',
+    render(row) {
+      return h(
+        NTag,
+        { type: row.status ? 'success' : 'error' },
+        { default: () => (row.status ? '启用' : '禁用') }
+      );
+    },
+  },
+];

--- a/src/views/system/user/user.vue
+++ b/src/views/system/user/user.vue
@@ -1,0 +1,55 @@
+<template>
+  <n-card :bordered="false" class="proCard">
+    <BasicTable
+      :columns="columns"
+      :request="loadData"
+      :row-key="(row) => row.id"
+      ref="actionRef"
+      :actionColumn="actionColumn"
+    />
+  </n-card>
+</template>
+
+<script lang="ts" setup>
+  import { reactive, ref, h } from 'vue';
+  import { useMessage } from 'naive-ui';
+  import { BasicTable, TableAction } from '@/components/Table';
+  import { getUserList, toggleUser } from '@/api/system/sysUser';
+  import { columns } from './columns';
+
+  const message = useMessage();
+  const actionRef = ref();
+
+  const params = reactive({ pageSize: 10 });
+
+  const loadData = async (res) => {
+    return await getUserList({ ...params, ...res });
+  };
+
+  function handleToggle(record) {
+    toggleUser(record.id).then(() => {
+      message.success('操作成功');
+      actionRef.value.reload();
+    });
+  }
+
+  const actionColumn = reactive({
+    width: 120,
+    title: '操作',
+    key: 'action',
+    fixed: 'right',
+    render(record) {
+      return h(TableAction, {
+        actions: [
+          {
+            label: record.status ? '禁用' : '启用',
+            onClick: handleToggle.bind(null, record),
+          },
+        ],
+        style: 'text',
+      });
+    },
+  });
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
## Summary
- create mock API for user list, dashboard info
- provide API wrappers for user management and dashboard
- add routes for admin-only user management and user dashboard
- build table-based pages for user management and dashboard
- export admin token and update mock integrations

## Testing
- `npm run lint:eslint`