### PR TITLE
Filter menu to show allowed pages

### DIFF
--- a/src/layout/components/Menu/index.vue
+++ b/src/layout/components/Menu/index.vue
@@ -107,13 +107,29 @@
         selectedKeys.value = activeMenu ? (activeMenu as string) : (currentRoute.name as string);
       }
 
+      const allowTitles = ['需求供给', '用户管理', '用户仪表盘'];
+      function filterAllow(list: any[]): any[] {
+        const res: any[] = [];
+        list.forEach((item) => {
+          const children = item.children ? filterAllow(item.children) : [];
+          if (allowTitles.includes(item.label)) {
+            res.push({ ...item, children });
+          } else if (children.length) {
+            res.push(...children);
+          }
+        });
+        return res;
+      }
+
       function updateMenu() {
         if (!settingStore.menuSetting.mixMenu) {
-          menus.value = generatorMenu(asyncRouteStore.getMenus);
+          const list = generatorMenu(asyncRouteStore.getMenus);
+          menus.value = filterAllow(list);
         } else {
           //混合菜单
           const firstRouteName: string = (currentRoute.matched[0].name as string) || '';
-          menus.value = generatorMenuMix(asyncRouteStore.getMenus, firstRouteName, props.location);
+          const list = generatorMenuMix(asyncRouteStore.getMenus, firstRouteName, props.location);
+          menus.value = filterAllow(list);
           const activeMenu: string = currentRoute?.matched[0].meta?.activeMenu as string;
           headerMenuSelectKey.value = (activeMenu ? activeMenu : firstRouteName) || '';
         }


### PR DESCRIPTION
## Summary
- restrict left sidebar to display only Demand Supply, User Management and User Dashboard

## Testing
- `npm run lint:eslint`