### PR TITLE
Add admin-only user management and dashboard data

### DIFF
--- a/mock/user/index.ts
+++ b/mock/user/index.ts
@@ -5,6 +5,7 @@ import { defineMock } from '@alova/mock';
 const Random = Mock.Random;
 
 export const adminToken = Random.string('upper', 32, 32);
+export const userToken = Random.string('upper', 32, 32);
 
 export const adminInfo = {
   userId: '1',
@@ -36,8 +37,28 @@ export const adminInfo = {
       value: 'basic_list_delete',
     },
     {
-      label: '用户管理',
+      label: '用户仪表盘',
+      value: 'user_dashboard',
+    },
+    {
+      label: '后台用户管理',
       value: 'system_user_manage',
+    },
+  ],
+};
+
+export const userInfo = {
+  userId: '2',
+  username: 'user',
+  realName: 'User',
+  avatar: Random.image(),
+  desc: 'member',
+  password: Random.string('upper', 4, 16),
+  token: userToken,
+  permissions: [
+    {
+      label: '主控台',
+      value: 'dashboard_console',
     },
     {
       label: '用户仪表盘',
@@ -47,6 +68,14 @@ export const adminInfo = {
 };
 
 export default defineMock({
-  '[POST]/api/login': () => resultSuccess({ token: adminToken }),
-  '/api/admin_info': () => resultSuccess(adminInfo),
+  '[POST]/api/login': ({ body }) => {
+    const { username } = body as { username: string };
+    const token = username === 'admin' ? adminToken : userToken;
+    return resultSuccess({ token });
+  },
+  '/api/admin_info': ({ headers }) => {
+    const token = headers?.token;
+    const info = token === adminToken ? adminInfo : userInfo;
+    return resultSuccess(info);
+  },
 });

--- a/src/router/modules/admin.ts
+++ b/src/router/modules/admin.ts
@@ -1,0 +1,31 @@
+import { RouteRecordRaw } from 'vue-router';
+import { Layout } from '@/router/constant';
+import { UserOutlined } from '@vicons/antd';
+import { renderIcon } from '@/utils/index';
+
+const routes: Array<RouteRecordRaw> = [
+  {
+    path: '/admin',
+    name: 'Admin',
+    redirect: '/admin/user',
+    component: Layout,
+    meta: {
+      title: '后台管理',
+      icon: renderIcon(UserOutlined),
+      sort: 99,
+    },
+    children: [
+      {
+        path: 'user',
+        name: 'admin_user',
+        meta: {
+          title: '后台用户管理',
+          permissions: ['system_user_manage'],
+        },
+        component: () => import('@/views/admin/user/index.vue'),
+      },
+    ],
+  },
+];
+
+export default routes;

--- a/src/views/admin/user/index.vue
+++ b/src/views/admin/user/index.vue
@@ -1,0 +1,55 @@
+<template>
+  <n-card :bordered="false" class="proCard">
+    <BasicTable
+      :columns="columns"
+      :request="loadData"
+      :row-key="(row) => row.id"
+      ref="actionRef"
+      :actionColumn="actionColumn"
+    />
+  </n-card>
+</template>
+
+<script lang="ts" setup>
+import { reactive, ref, h } from 'vue';
+import { useMessage } from 'naive-ui';
+import { BasicTable, TableAction } from '@/components/Table';
+import { getUserList, toggleUser } from '@/api/system/sysUser';
+import { columns } from '@/views/system/user/columns';
+
+const message = useMessage();
+const actionRef = ref();
+
+const params = reactive({ pageSize: 10 });
+
+const loadData = async (res) => {
+  return await getUserList({ ...params, ...res });
+};
+
+function handleToggle(record) {
+  toggleUser(record.id).then(() => {
+    message.success('操作成功');
+    actionRef.value.reload();
+  });
+}
+
+const actionColumn = reactive({
+  width: 120,
+  title: '操作',
+  key: 'action',
+  fixed: 'right',
+  render(record) {
+    return h(TableAction, {
+      actions: [
+        {
+          label: record.status ? '禁用' : '启用',
+          onClick: handleToggle.bind(null, record),
+        },
+      ],
+      style: 'text',
+    });
+  },
+});
+</script>
+
+<style scoped></style>

--- a/src/views/dashboard/user/user.vue
+++ b/src/views/dashboard/user/user.vue
@@ -1,7 +1,7 @@
 <template>
   <n-card :bordered="false" class="proCard">
     <BasicTable
-      title="用户数据"
+      :title="isAdmin ? '所有用户数据' : '我的数据'"
       :columns="columns"
       :request="loadData"
       :row-key="(row) => row.id"
@@ -10,10 +10,16 @@
 </template>
 
 <script lang="ts" setup>
-  import { reactive } from 'vue';
+  import { reactive, computed } from 'vue';
   import { BasicTable } from '@/components/Table';
   import { getUserDashboard } from '@/api/dashboard/user';
+  import { useUserStore } from '@/store/modules/user';
   import { columns } from './columns';
+
+  const userStore = useUserStore();
+  const isAdmin = computed(() =>
+    userStore.getPermissions.some((p) => p.value === 'system_user_manage')
+  );
 
   const params = reactive({});
 


### PR DESCRIPTION
## Summary
- extend mock user data with admin and normal user accounts
- return user info and token based on login credentials
- add Admin route and user management page for toggling user status
- update user dashboard to show all user data for admin only

## Testing
- `pnpm lint:eslint` *(fails: ESLint couldn't find config)*