### PR TITLE
Integrate user pages with v1 endpoints

### DIFF
--- a/mock/dashboard/user.ts
+++ b/mock/dashboard/user.ts
@@ -13,7 +13,7 @@ function makeUser() {
 }
 
 export default defineMock({
-  '/api/dashboard/user': ({ headers }) => {
+  '/v1/user/dashboard': ({ headers }) => {
     const isAdmin = headers?.token === adminToken;
     const list = isAdmin ? Array.from({ length: 5 }, makeUser) : [makeUser()];
     return resultSuccess({ list });

--- a/mock/system/user.ts
+++ b/mock/system/user.ts
@@ -16,7 +16,7 @@ function userList(pageSize: number) {
 }
 
 export default defineMock({
-  '/api/user/list': ({ query }) => {
+  '/v1/user/list': ({ query }) => {
     const { page = 1, pageSize = 10 } = query;
     const list = userList(Number(pageSize));
     const count = 60;
@@ -28,7 +28,7 @@ export default defineMock({
       list,
     });
   },
-  '/api/user/toggle/:id': () => {
+  '/v1/user/toggle/:id': () => {
     return resultSuccess(true);
   },
 });

--- a/src/api/dashboard/user.ts
+++ b/src/api/dashboard/user.ts
@@ -8,5 +8,5 @@ export interface UserDashboardItem {
 }
 
 export function getUserDashboard(params?) {
-  return Alova.Get<{ list: UserDashboardItem[] }>('/dashboard/user', { params });
+  return Alova.Get<{ list: UserDashboardItem[] }>('/v1/user/dashboard', { params });
 }

--- a/src/api/system/sysUser.ts
+++ b/src/api/system/sysUser.ts
@@ -9,9 +9,9 @@ export interface SysUserItem {
 }
 
 export function getUserList(params?) {
-  return Alova.Get<{ list: SysUserItem[] }>('/user/list', { params });
+  return Alova.Get<{ list: SysUserItem[] }>('/v1/user/list', { params });
 }
 
 export function toggleUser(id: number) {
-  return Alova.Post(`/user/toggle/${id}`);
+  return Alova.Post(`/v1/user/toggle/${id}`);
 }


### PR DESCRIPTION
## Summary
- align system user APIs with `/v1` routes
- update dashboard/user mock to new endpoint
- update system/user mock to new endpoint

## Testing
- `pnpm lint:eslint` *(fails: ESLint couldn't find config)*